### PR TITLE
Fixed project name not correctly handling underscores and hyphens.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -163,18 +163,17 @@ entrypoint:
 - "-c"
 - |
   [ -f .env ] && export $(grep -v '^#' .env | xargs) && [ -f .env.local ] && export $(grep -v '^#' .env.local | xargs)
-  PROJECT_NAME=${PROJECT_NAME:-$(basename $(pwd))} && export PROJECT_NAME=${PROJECT_NAME/[_]/}
+  export PROJECT_NAME=${PROJECT_NAME:-$(basename $(pwd))}
   export APP=${APP:-/app}
   export WEBROOT=${WEBROOT:-docroot}
   export MYSQL_HOST=${MYSQL_HOST:-mariadb}
   export MYSQL_PORT=${MYSQL_PORT:-3306}
   export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-$PROJECT_NAME}
-  export LOCALDEV_URL=${LOCALDEV_URL:-http://$PROJECT_NAME.docker.amazee.io}
+  export LOCALDEV_URL=${LOCALDEV_URL:-http://${PROJECT_NAME/[_ ]/-}.docker.amazee.io}
   export COMPOSER=${COMPOSER:-composer.json}
   export DRUPAL_PROFILE=${DRUPAL_PROFILE:-}
   export DRUPAL_MODULE_PREFIX=${DRUPAL_MODULE_PREFIX:-mysite}
-  PHPCS_TARGETS=${PHPCS_TARGETS:-.}
-  export PHPCS_TARGETS=${PHPCS_TARGETS//,/ }
+  PHPCS_TARGETS=${PHPCS_TARGETS:-.} && export PHPCS_TARGETS=${PHPCS_TARGETS//,/ }
   if [ "$CI" ]; then export ES_TPL=elasticsearch.ci.yml; fi
   bash -c "$0" "$@"
 - '{{cmd}}'

--- a/.env
+++ b/.env
@@ -12,8 +12,7 @@
 # This file may be left as is to assume default values specified in .ahoy.yml.
 
 # Project name.
-# Defaults to the name of the current directory with stripped hyphens and
-# underscores.
+# Defaults to the name of the current directory.
 # PROJECT_NAME=mysite
 
 # Docker Compose project name.


### PR DESCRIPTION
`PROJECT_NAME` should not be changed from how it actually been specified. It had erroneous  code to strip underscores in order to make the local dev URL to not contain underscores.
As a byproduct of this - the docker compose project name was affected as well, resulting in all containers having underscores stripped, which is not a standard behaviour of docker compose (it just uses the dir name): `tide_api` would become `tideapi`.


This PR addresses this problem and applies stripping of underscore only for URL.
It also adds replacement of the space character with hyphen in URL.

The test build of the project that uses this change is here
https://circleci.com/workflow-run/583e1ca3-315c-4ee8-a115-55f5865d98ba