### PR TITLE
Fixed composer scripts.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -106,10 +106,6 @@ commands:
         ahoy cli -- ./scripts/rebuild-env.sh
       fi
 
-  db-import:
-    usage: Import the production database.
-    cmd: ahoy cli -- ./scripts/rebuild-env.sh
-
   fix-bay-token:
     usage: Fix the bay token by re-importing.
     cmd: |

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -106,6 +106,10 @@ commands:
         ahoy cli -- ./scripts/rebuild-env.sh
       fi
 
+  db-import:
+    usage: Import the production database.
+    cmd: ahoy cli -- ./scripts/rebuild-env.sh
+
   fix-bay-token:
     usage: Fix the bay token by re-importing.
     cmd: |

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -182,12 +182,13 @@
         ],
         "post-install-cmd": [
             "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-            "rm -f docroot/sites/default/settings.php",
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
             "Utilities\\composer\\DrupalSettings::create"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "Utilities\\composer\\DrupalSettings::create"
         ]
     },
     "extra": {


### PR DESCRIPTION
- Fixed composer script handler not correctly working with settings files when provisioned inside of the container. This leads to inability to install projects with `ahoy build` from the first time.

Test build for this change from `tide-page` module https://circleci.com/workflow-run/8fd39a99-12a0-443c-984c-c61744371b4e