### PR TITLE
Fixed clean command not removing temp composer files.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -144,7 +144,8 @@ commands:
       && ([ -d .git ] && git ls-files --directory --other -i --exclude-from=.gitignore ${WEBROOT} | grep -v "settings.local.php" | grep -v "services.local.yml" | xargs chmod -Rf 777 || true) \
       && ([ -d .git ] && git ls-files --directory --other -i --exclude-from=.gitignore ${WEBROOT} | grep -v "settings.local.php" | grep -v "services.local.yml" | xargs rm -Rf || true) \
       && rm -Rf vendor \
-      && rm -Rf screenshots
+      && rm -Rf screenshots \
+      && rm -Rf composer.build.*
 
   clean-full:
     usage: Remove all development files.


### PR DESCRIPTION
Small, but important change.

Without this change, when changing the branch and running `ahoy build` that would generate new `composer.build.json` with new dependencies, `composer.build.lock` was not removed making composer install  different (previous) dependencies that were in `composer.build.json`.