### PR TITLE
Pinned Chrome image to v74.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       lagoon.type: none
 
   chrome:
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:3.141.59-oxygen
     shm_size: '1gb'
     environment:
       << : *default-environment


### PR DESCRIPTION
https://medium.com/@alex.designworks/chromedriver-75-enforces-w3c-standard-breaking-behat-tests-460cad435545