### PR TITLE
Update dev-require for behat/mink-selenium2-driver

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "behat/behat": "^3.5",
-        "behat/mink-selenium2-driver": "1.3.x-dev",
+        "behat/mink-selenium2-driver": "^1.3.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "drupal/coder": "^8.2.12",
         "drupal/console": "^1.0",


### PR DESCRIPTION
`1.3.x-dev` branch of `behat/mink-selenium2-driver` has been superseded by `1.4.x-dev`. This change grabs the latest available version of the 1.3 branch. 