### PR TITLE
Added conditional check for screenshot dir

### DIFF
--- a/.circleci/test-artifacts.sh
+++ b/.circleci/test-artifacts.sh
@@ -4,4 +4,8 @@
 #
 set -e
 
-docker cp $(docker-compose ps -q cli):/app/screenshots /tmp/artifacts/behat
+SCREENSHOT_DIR="$(docker exec $(docker-compose ps -q cli) sh -c "test -d /app/screenshots" && echo $?)"
+
+if [[ $SCREENSHOT_DIR == 0 ]]; then
+  docker cp $(docker-compose ps -q cli):/app/screenshots /tmp/artifacts/behat
+fi

--- a/.circleci/test-artifacts.sh
+++ b/.circleci/test-artifacts.sh
@@ -4,8 +4,10 @@
 #
 set -e
 
-SCREENSHOT_DIR="$(docker exec $(docker-compose ps -q cli) sh -c "test -d /app/screenshots" && echo $?)"
+# Create screenshots directory in case it was not created before. This is to
+# avoid this script to fail when copying artifacts.
+ahoy cli "mkdir -p /app/screenshots"
 
-if [[ $SCREENSHOT_DIR == 0 ]]; then
-  docker cp $(docker-compose ps -q cli):/app/screenshots /tmp/artifacts/behat
-fi
+# Copy from the app container to the build host for storage.
+mkdir -p /tmp/artifacts/behat
+docker cp $(docker-compose ps -q cli):/app/screenshots /tmp/artifacts/behat


### PR DESCRIPTION
If a project's test profile doesn't define any tests `ahoy test-behat` will not create the screenshots directory and the `.circleci/test-artifacts.sh` script will cause the CI step "Copy artifacts" to fail

### Changes
1. Added a conditional check for the presence of the screenshots directory.