### PR TITLE
Fixed unable download error

### DIFF
--- a/install
+++ b/install
@@ -33,8 +33,7 @@ if [ "$GH_COMMIT" != "" ]; then
 else
   echo "==> Downloading the latest version of Dev Tools"
   curl -s -L "https://api.github.com/repos/$GH_ORG/$GH_PROJECT/releases/latest" \
-    | grep '"tag_name":' \
-    | sed -E 's/.*"([^"]+)".*/\1/' \
+    | sed -E 's/.*tag_name":\s*"([^,]*)",.*/\1/'
     | xargs -I {} curl -L "https://github.com/$GH_ORG/$GH_PROJECT/archive/"{}'.tar.gz' \
     | tar xvzf - -C $TMP_DIR --strip 1
 fi


### PR DESCRIPTION
This `Downloading the latest version of Dev Tools` task has never worked for me. I tried debug and found `curl -s -L "https://api.github.com/repos/$GH_ORG/$GH_PROJECT/releases/latest"` in my mac command line will return json response without and line breaks, thus the grep won't work out the tag name. This modified command will make sure work with that json response.

<img width="884" alt="Screen Shot 2019-11-22 at 1 12 12 pm" src="https://user-images.githubusercontent.com/31641325/69392311-b9c90280-0d29-11ea-9926-59df2a5977bd.png">
