### PR TITLE
[SDPAA-816] Added support for database images.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -33,6 +33,11 @@ commands:
   up:
     usage: Build and start Docker containers.
     cmd: |
+      # Log into to Github docker registry if custom MYSQL_IMAGE is set.
+      if [ "$MYSQL_IMAGE" ]; then
+        GITHUB_USER=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | jq -r .login)
+        echo $GITHUB_TOKEN | docker login docker.pkg.github.com -u "${GITHUB_USER}" --password-stdin
+      fi
       docker-compose up -d "$@" \
       && ahoy cli "dockerize -wait tcp://mariadb:3306 -timeout 1m" \
       && if docker-compose logs | grep -q "\[Error\]"; then docker-compose logs; exit 1; fi \
@@ -102,6 +107,9 @@ commands:
       ahoy flush-redis
       if [ "$INSTALL_NEW_SITE" == "1" ]; then
         ahoy cli -- ./scripts/drupal/install-new-site.sh
+      elif [ "${MYSQL_IMAGE}" ]; then
+        ahoy line "DB image ${MYSQL_IMAGE} in use - skipping sync"
+        ahoy cli -- ./scripts/drupal/deploy.sh
       else
         ahoy cli -- ./scripts/rebuild-env.sh
       fi

--- a/.env
+++ b/.env
@@ -35,6 +35,7 @@
 # LOCALDEV_URL=http://mysite.docker.amazee.io
 
 # Database connection details.
+# MYSQL_IMAGE=docker.pkg.github.com/dpc-sdp/<CURRENTDIR>/db:production-latest
 # MYSQL_HOST=mariadb
 # MYSQL_PORT=3306
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Tagging a test with `@suggest` means that it will run only for
 Tagging a test with `@nosuggest` means that the test will run only in normal mode. 
 Not providing a tag will run test in both modes.
 
+#### How to use prepopulated database images?
+In the `.env` file for the tide project, set the `MYSQL_IMAGE` variable with the 
+image registry location. Omitting this value will default to the standard 
+amazeeio image. 
+
 ## Workflow recipes
 
 ### Using Dev Tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       lagoon.name: nginx-php
 
   mariadb:
-    image: amazeeio/mariadb-drupal
+    image: ${MYSQL_IMAGE:-amazeeio/mariadb-drupal}
     environment:
       << : *default-environment
     ports:


### PR DESCRIPTION
This PR summarize the touch-points for each tide project that wants to use database images.

- The project `.env` file needs to set the `MYSQL_IMAGE` environment variable.
- `docker-compose.yml` needs to use the db image set in `MYSQL_IMAGE` variable, if configured.
- `ahoy up` needs to ensure docker can pull from the github registry. 
- `ahoy install-site` doesnt need to sync the database from production.