### PR TITLE
[SDPA-4334] Added ckeditor lisstyle plugin repository.

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -196,6 +196,21 @@
                 }
             }
         },
+        "ckeditor/liststyle": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/liststyle",
+                "version": "4.8.0",
+                "type": "drupal-library",
+                "extra": {
+                    "installer-name": "ckeditor/plugins/liststyle"
+                },
+                "dist": {
+                    "url": "https://download.ckeditor.com/liststyle/releases/liststyle_4.8.0.zip",
+                    "type": "zip"
+                }
+            }
+        },
         "ckeditor/templates": {
             "type": "package",
             "package": {


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4334

### Changes
Added CKeditor list-style repository for tide_core to pass the build.

### Related PR - 
https://github.com/dpc-sdp/tide_core/pull/184