### PR TITLE
pin 'squizlabs/php_codesniffer' to 3.5.6

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -14,6 +14,7 @@
     "require-dev": {
         "behat/behat": "^3.5",
         "behat/mink-selenium2-driver": "^1.3.1",
+        "squizlabs/php_codesniffer": "3.5.6",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "drupal/coder": "^8.2.12",
         "drupal/console": "^1.0",


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4745
### Issues
1. pin `squizlabs/php_codesniffer` to 3.5.6 to avoid lint errors.
```bash
==> Lint code
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function DrupalPractice\Sniffs\CodeAnalysis\ScopeInfo::__construct(), 0 passed in /app/vendor/squizlabs/php_codesniffer/src/Ruleset.php on line 1209 and exactly 1 expected in /app/vendor/drupal/coder/coder_sniffer/DrupalPractice/Sniffs/CodeAnalysis/VariableAnalysisSniff.php:49
Stack trace:
#0 /app/vendor/squizlabs/php_codesniffer/src/Ruleset.php(1209): DrupalPractice\Sniffs\CodeAnalysis\ScopeInfo->__construct()
#1 /app/vendor/squizlabs/php_codesniffer/src/Ruleset.php(218): PHP_CodeSniffer\Ruleset->populateTokenListeners()
#2 /app/vendor/squizlabs/php_codesniffer/src/Runner.php(332): PHP_CodeSniffer\Ruleset->__construct(Object(PHP_CodeSniffer\Config))
#3 /app/vendor/squizlabs/php_codesniffer/src/Runner.php(70): PHP_CodeSniffer\Runner->init()
#4 /app/vendor/squizlabs/php_codesniffer/bin/phpcs(18): PHP_CodeSniffer\Runner->runPHPCS()
#5 {main}
  thrown in /app/vendor/drupal/coder/coder_sniffer/DrupalPractice/Sniffs/CodeAnalysis/VariableAnalysisSniff.php on line 49
```