### PR TITLE
[bump_up_tide_core] Upgraded tide_core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "dpc-sdp/tide_core": "^1.6.0"
+        "dpc-sdp/tide_core": "^2.0.0"
     },
     "suggest": {
         "dpc-sdp/tide_media:^1.7.0": "Media and related configuration for Tide Drupal 8 distribution"


### PR DESCRIPTION
### Changes
As there were some breaking changes in tide_core, now the tide_core is bumped up to 2.0.0. Because of this change, the version of tide_core needs to be updated here.