### PR TITLE
Adds phpunit to dev-tools

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -10,3 +10,7 @@ ahoy lint
 echo "==> Run Behat tests"
 mkdir -p /tmp/artifacts/behat
 ahoy test-behat || ahoy test-behat -- --rerun
+
+echo "==> Run Unit tests"
+mkdir -p /tmp/unit_test
+../vendor/bin/phpunit

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -12,5 +12,4 @@ mkdir -p /tmp/artifacts/behat
 ahoy test-behat || ahoy test-behat -- --rerun
 
 echo "==> Run Unit tests"
-mkdir -p /tmp/unit_test
-../vendor/bin/phpunit
+ahoy cli "/app/vendor/bin/phpunit"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Finally, we install the module itself.
 1. Uncomment this line in `docker-compose.yml`:
   ```
   #XDEBUG_ENABLE: "true"
+  #DOCKERHOST: "host.docker.internal"
   ```
 2. Restart the stack: `ahoy up`.
 3. Enable listening for incoming debug connections in your IDE.
@@ -181,3 +182,14 @@ To make a change:
 6. If the build passes, merge the Dev Tools branch to `master` and make a release.
     - NOTE: This must be a release in GitHub, see https://github.com/dpc-sdp/dev-tools/releases/new
 7. Remove the temporary branch in `tide_*` module from Step 3. 
+
+## Unit test
+The dev-tools supports unit tests. 
+### Registering tests
+#### Directory
+1. The unit tests should go in `tests\src\Unit` direcotry. 
+2. The unit tests need to respect PSR-4 namespace naming convention, in our case, 
+    `namespace Drupal\Tests\{module}\Unit`
+### 2 ways to run tests
+1. commit to CI.
+2. Run `./vendor/bin/phpunit` inside CLI container locally.

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -25,7 +25,8 @@
         "phpcompatibility/php-compatibility": "^9.1",
         "ubirak/rest-api-behat-extension": "dev-feature/drupalextension-compatibility as 7.0.0",
         "symfony/filesystem": "^3.2.8",
-        "php-http/curl-client": "^1.7"
+        "php-http/curl-client": "^1.7",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "classmap": [

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -26,7 +26,7 @@
         "ubirak/rest-api-behat-extension": "dev-feature/drupalextension-compatibility as 7.0.0",
         "symfony/filesystem": "^3.2.8",
         "php-http/curl-client": "^1.7",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "classmap": [

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -26,7 +26,8 @@
         "ubirak/rest-api-behat-extension": "dev-feature/drupalextension-compatibility as 7.0.0",
         "symfony/filesystem": "^3.2.8",
         "php-http/curl-client": "^1.7",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5",
+        "drupal/core-dev":"8.9.x"
     },
     "autoload": {
         "classmap": [

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -27,7 +27,8 @@
         "symfony/filesystem": "^3.2.8",
         "php-http/curl-client": "^1.7",
         "phpunit/phpunit": "^6.5",
-        "drupal/core-dev":"8.9.x"
+        "drupal/core-dev":"8.9.x",
+        "weitzman/drupal-test-traits": "1.4.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -26,7 +26,7 @@
         "ubirak/rest-api-behat-extension": "dev-feature/drupalextension-compatibility as 7.0.0",
         "symfony/filesystem": "^3.2.8",
         "php-http/curl-client": "^1.7",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "classmap": [

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -27,8 +27,7 @@
         "symfony/filesystem": "^3.2.8",
         "php-http/curl-client": "^1.7",
         "phpunit/phpunit": "^6.5",
-        "drupal/core-dev":"8.9.x",
-        "weitzman/drupal-test-traits": "1.4.0"
+        "drupal/core-dev":"8.9.x"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "dpc-sdp/tide_core": "^2.0.0"
+        "dpc-sdp/tide_core": "dev-feature/remove-refactor_xss_attributes-3109650"
     },
     "suggest": {
         "dpc-sdp/tide_media:^1.7.0": "Media and related configuration for Tide Drupal 8 distribution"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/remove-refactor_xss_attributes-3109650"
+        "dpc-sdp/tide_core": "^2.0.0"
     },
     "suggest": {
         "dpc-sdp/tide_media:^1.7.0": "Media and related configuration for Tide Drupal 8 distribution"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,34 +25,34 @@
      SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
      external DDev URL so you can follow the links directly.
     -->
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+<!--    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>-->
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
-    <env name="MINK_DRIVER_CLASS" value=''/>
+<!--    <env name="MINK_DRIVER_CLASS" value=''/>-->
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
-    <env name="MINK_DRIVER_ARGS" value=''/>
+<!--    <env name="MINK_DRIVER_ARGS" value=''/>-->
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+<!--    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>-->
     <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+<!--    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>-->
   </php>
   <testsuites>
     <testsuite name="unit">
-      <file>./tests/TestSuites/UnitTestSuite.php</file>
+      <directory>./dpc-sdp/*/tests/src/Unit</directory>
     </testsuite>
-    <testsuite name="kernel">
-      <file>./tests/TestSuites/KernelTestSuite.php</file>
-    </testsuite>
-    <testsuite name="functional">
-      <file>./tests/TestSuites/FunctionalTestSuite.php</file>
-    </testsuite>
-    <testsuite name="functional-javascript">
-      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
-    </testsuite>
-    <testsuite name="build">
-      <file>./tests/TestSuites/BuildTestSuite.php</file>
-    </testsuite>
+<!--    <testsuite name="kernel">-->
+<!--      <file>./tests/TestSuites/KernelTestSuite.php</file>-->
+<!--    </testsuite>-->
+<!--    <testsuite name="functional">-->
+<!--      <file>./tests/TestSuites/FunctionalTestSuite.php</file>-->
+<!--    </testsuite>-->
+<!--    <testsuite name="functional-javascript">-->
+<!--      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>-->
+<!--    </testsuite>-->
+<!--    <testsuite name="build">-->
+<!--      <file>./tests/TestSuites/BuildTestSuite.php</file>-->
+<!--    </testsuite>-->
   </testsuites>
   <listeners>
     <listener class="\Drupal\Tests\Listeners\DrupalListener">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="vender/weitzman/drupal-test-traits/src/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value=""/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value=""/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>./tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>./tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>./tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./tests/TestSuites/BuildTestSuite.php</file>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+      </exclude>
+      <directory>../modules</directory>
+      <exclude>
+        <directory>../modules/*/src/Tests</directory>
+        <directory>../modules/*/tests</directory>
+        <directory>../modules/*/*/src/Tests</directory>
+        <directory>../modules/*/*/tests</directory>
+      </exclude>
+      <directory>../sites</directory>
+     </whitelist>
+  </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
  or your current system user. See core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
-<phpunit bootstrap="vender/weitzman/drupal-test-traits/src/bootstrap.php" colors="true"
+<phpunit bootstrap="docroot/core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
@@ -16,11 +16,11 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-    <env name="SIMPLETEST_BASE_URL" value=""/>
+    <env name="SIMPLETEST_BASE_URL" value="http://nginx:8080"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-    <env name="SIMPLETEST_DB" value=""/>
+    <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@mariadb:3306/drupal"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/unit_test"/>
     <!-- To have browsertest output use an alternative base URL. For example if
      SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
      external DDev URL so you can follow the links directly.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@mariadb:3306/drupal"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/unit_test"/>
+<!--    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/unit_test"/>-->
     <!-- To have browsertest output use an alternative base URL. For example if
      SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
      external DDev URL so you can follow the links directly.


### PR DESCRIPTION
### Motivation
1. we would like standardised unit tests for our modules, we raised this requirement in a dev meeting in last year.
2. it is part of my PDP 😬 

actual unit tests should reside in each tide_* modules.

ok, it runs under CI. 
it is ready to roll out to all tide_* modules. and this update focuses `unit` test only. 