### PR TITLE
[DDS-901] Updated package.

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -169,6 +169,38 @@
                 }
             }
         },
+        "ckeditor.autogrow": {
+            "_webform": true,
+            "type": "package",
+            "package": {
+                "name": "ckeditor/autogrow",
+                "version": "4.16.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/autogrow/releases/autogrow_4.16.1.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        "ckeditor.codemirror": {
+            "_webform": true,
+            "type": "package",
+            "package": {
+                "name": "ckeditor/codemirror",
+                "version": "v1.17.12",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://github.com/w8tcha/CKEditor-CodeMirror-Plugin/releases/download/v1.17.12/CKEditor-CodeMirror-Plugin.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
         "ckeditor/iframe": {
             "type": "package",
             "package": {
@@ -200,6 +232,38 @@
                 }
             }
         },
+        "ckeditor.image": {
+            "_webform": true,
+            "type": "package",
+            "package": {
+                "name": "ckeditor/image",
+                "version": "4.16.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/image/releases/image_4.16.1.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        "ckeditor.link": {
+            "_webform": true,
+            "type": "package",
+            "package": {
+                "name": "ckeditor/link",
+                "version": "4.16.1",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/link/releases/link_4.16.1.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
         "ckeditor/liststyle": {
             "type": "package",
             "package": {
@@ -224,6 +288,44 @@
                 "dist": {
                     "type": "zip",
                     "url": "https://download.ckeditor.com/templates/releases/templates_4.5.7.zip"
+                }
+            }
+        },
+        "jquery.timepicker": {
+            "_webform": true,
+            "type": "package",
+            "package": {
+                "name": "jquery/timepicker",
+                "version": "1.13.14",
+                "type": "drupal-library",
+                "extra": {
+                    "installer-name": "jquery.timepicker"
+                },
+                "dist": {
+                    "url": "https://github.com/jonthornton/jquery-timepicker/archive/1.13.14.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        "jquery.textcounter": {
+            "_webform": true,
+            "type": "package",
+            "package": {
+                "name": "jquery/textcounter",
+                "version": "0.9.0",
+                "type": "drupal-library",
+                "extra": {
+                    "installer-name": "jquery.textcounter"
+                },
+                "dist": {
+                    "url": "https://github.com/ractoon/jQuery-Text-Counter/archive/0.9.0.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
                 }
             }
         },

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -185,14 +185,15 @@
             }
         },
         "ckeditor/fakeobjects": {
+            "_webform": true,
             "type": "package",
             "package": {
                 "name": "ckeditor/fakeobjects",
+                "version": "4.16.1",
                 "type": "drupal-library",
-                "version": "4.5.11",
                 "dist": {
-                    "type": "zip",
-                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.5.11.zip"
+                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.16.1.zip",
+                    "type": "zip"
                 },
                 "require": {
                     "composer/installers": "~1.0"


### PR DESCRIPTION
This needs to be added in dev-tools, else the tide modules that are dependant on tide_core fails in CI.
Also, all the packages need to be removed from tide_core and release tasks might be needed to add it in the root composer.