### PR TITLE
Updated CI builder image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &job-build
     working_directory: /app
     docker:
-      - image: &builder-image integratedexperts/ci-builder
+      - image: &builder-image drevops/ci-builder
         environment:
           INSTALL_NEW_SITE: 1
           LAGOON_ENVIRONMENT_TYPE: ci


### PR DESCRIPTION
`integratedexperts/ci-builder` was moved to the new namespace `drevops/ci-builder` a while ago. The `integratedexperts/ci-builder` has not been maintained for a while.
`drevops/ci-builder` is still actively maintained and has all the features of `integratedexperts/ci-builder` plus more test coverage and additional tools.