### PR TITLE
[SDPA-5674] Update to PHP 7.4 feature level

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,7 +12,7 @@
     <arg name="parallel" value="75"/>
     <!--Lint code against platform version specified in composer.json
     key "config.platform.php".-->
-    <config name="testVersion" value="7.3"/>
+    <config name="testVersion" value="7.4"/>
 
     <exclude-pattern>*/docroot/*</exclude-pattern>
     <exclude-pattern>*/console/*</exclude-pattern>


### PR DESCRIPTION
1) Update linting to PHP 7.4 feature level.

```
[tide_core]cli-drupal:/app$ php -v
PHP 7.4 (cli) (built: Aug 27 2021 21:53:25) ( NTS )
```