### PR TITLE
Added composer changes.

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -42,7 +42,15 @@
             "php": "7.3"
         },
         "process-timeout": 0,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+          "composer/installers": true,
+          "oomphinc/composer-installers-extender": true,
+          "drupal/*": true,
+          "cweagans/composer-patches": true,
+          "zaporylie/composer-drupal-optimizations": false,
+          "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
### Issue
Reference to this conversation - https://github.com/dpc-sdp/content-vic-gov-au/pull/1380#discussion_r882248359
Apparently if allow-plugins is not added by July 2002 then Composer will stop loading plugins altogether. This would stop Drupal installing properly.
It was added for all projects root composer but it needs to be added here to pass the build for all tide modules.
It causes build fail in CI reference - https://app.circleci.com/pipelines/github/dpc-sdp/tide_media/316/workflows/0d6a8a67-4f4e-4d93-ac17-6683798c6057
After using this dev-tools commit reference it passes the build - https://app.circleci.com/pipelines/github/dpc-sdp/tide_media/317/workflows/6d417123-c6d6-4aa2-9f34-aee79ac8b4a6