### PR TITLE
Release/1.1.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &job-build
     working_directory: /app
     docker:
-      - image: &builder-image singledigital/bay-ci-builder:4.x
+      - image: &builder-image singledigital/bay-ci-builder:5.x
         environment:
           INSTALL_NEW_SITE: 1
           LAGOON_ENVIRONMENT_TYPE: ci

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-ARG BAY_IMAGE_VERSION=4.x
+ARG BAY_IMAGE_VERSION=5.x
 
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
 FROM singledigital/bay-cli:${BAY_IMAGE_VERSION}

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -1,6 +1,6 @@
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.nginx
 ARG CLI_IMAGE
-ARG BAY_IMAGE_VERSION=4.x
+ARG BAY_IMAGE_VERSION=5.x
 
 FROM ${CLI_IMAGE:-cli} as cli
 

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -1,6 +1,6 @@
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
 ARG CLI_IMAGE
-ARG BAY_IMAGE_VERSION=4.x
+ARG BAY_IMAGE_VERSION=5.x
 
 FROM ${CLI_IMAGE:-cli} as cli
 

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "behat/behat": "^3.5",
         "behat/mink-selenium2-driver": "^1.4",
-        "squizlabs/php_codesniffer": "3.5.6",
+        "squizlabs/php_codesniffer": "3.7.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "drupal/coder": "^8.3.10",
         "drupal/console": "^1.0",
@@ -41,9 +41,6 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "config": {
-        "platform": {
-            "php": "7.3"
-        },
         "process-timeout": 0,
         "sort-packages": true,
         "allow-plugins": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 version: '2.3'
 
 x-bay-image-version:
-  &bay-image-version ${BAY_IMAGE_VERSION:-4.x}
+  &bay-image-version ${BAY_IMAGE_VERSION:-5.x}
 
 x-project:
   &project ${PROJECT_NAME:-mysite}
@@ -40,7 +40,7 @@ x-environment:
   LAGOON_LOCALDEV_URL: ${LOCALDEV_URL:-http://mysite.docker.amazee.io}
   GITHUB_TOKEN: ${GITHUB_TOKEN:-}
   BAY_KEY: ${BAY_KEY:-}
-  BAY_IMAGE_VERSION: ${BAY_IMAGE_VERSION:-4.x}
+  BAY_IMAGE_VERSION: ${BAY_IMAGE_VERSION:-5.x}
   LAGOON_ENVIRONMENT_TYPE: ${LAGOON_ENVIRONMENT_TYPE:-local}
   DRUPAL_REFRESH_SEARCHAPI: ${DRUPAL_REFRESH_SEARCHAPI:-}
   # Uncomment to enable Xdebug and then restart via `ahoy up`.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,7 +12,7 @@
     <arg name="parallel" value="75"/>
     <!--Lint code against platform version specified in composer.json
     key "config.platform.php".-->
-    <config name="testVersion" value="7.4"/>
+    <config name="testVersion" value="8.1"/>
 
     <exclude-pattern>*/docroot/*</exclude-pattern>
     <exclude-pattern>*/console/*</exclude-pattern>

--- a/scripts/composer/DrupalSettings.php
+++ b/scripts/composer/DrupalSettings.php
@@ -170,7 +170,7 @@ FILE;
 
     foreach ($arguments as $argument) {
       if (strpos($argument, '--') === 0) {
-        list($name, $value) = explode('=', $argument);
+        [$name, $value] = explode('=', $argument);
         $name = substr($name, strlen('--'));
         $options[$name] = $value;
         if (array_key_exists($name, $allowed) && !is_null($value)) {


### PR DESCRIPTION
Release/1.1.6

### Changes
Added updates related to php 8.1 and use the latest bay image version

I have used this PR to build this tide_core PR and it resolves the new lint issues as well. 
https://github.com/dpc-sdp/tide_core/pull/357