### PR TITLE
Update drupalcore to 9.5.x

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -6,7 +6,7 @@
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.6.0",
         "drupal/core-composer-scaffold": "^10.0",
-        "drupal/core": "9.4.x",
+        "drupal/core": "9.5.x",
         "drush/drush": "^10",
         "vlucas/phpdotenv": "^4.1",
         "webflo/drupal-finder": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SRM-797-update-sdp-to-9-5-x as 3.1.0"
+        "dpc-sdp/tide_core": "^3.1.0"
     },
     "suggest": {
         "dpc-sdp/tide_media:^3.0.0": "Media and related configuration for Tide Drupal 8 distribution"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "require": {
-        "dpc-sdp/tide_core": "^3.1.0"
+        "dpc-sdp/tide_core": "dev-feature/SRM-797-update-sdp-to-9-5-x as 3.1.0"
     },
     "suggest": {
         "dpc-sdp/tide_media:^3.0.0": "Media and related configuration for Tide Drupal 8 distribution"


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SRM-797

### Problem/Motivation
Drupal 9.4.x is end of life on June 21, 2023.

### Fix
Update drupal/core to `9.5.x`