### PR TITLE
Update dev stack for all tide libraries that still use dev tools

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -21,13 +21,13 @@ commands:
   info:
     usage: Print information about this project.
     cmd: |
-      ahoy line "Site URL              : " ${LOCALDEV_URL}
+      ahoy line "Site URL              : " ${LOCALDEV_URL}:${LOCAL_PORT:-80}/
       ahoy line "Path to project       : " ${APP}
       ahoy line "Path to docroot       : " ${APP}/${WEBROOT}
       ahoy line "DB port on host       : " $(docker port $(docker-compose ps -q mariadb) 3306 | cut -d : -f 2)
-      ahoy line "Mailhog URL           : " http://mailhog.docker.amazee.io/
+      ahoy line "Mailhog URL           : " http://mailhog.docker.internal:${LOCAL_PORT:-80}/
       if [ "$1" ]; then
-        ahoy line "One-time login        : " $(ahoy login)
+        ahoy line "One-time login        : " $(ahoy login -- --no-browser)
       fi
 
   up:
@@ -180,22 +180,22 @@ commands:
     hide: true
 
 entrypoint:
-- bash
-- "-c"
-- |
-  [ -f .env ] && export $(grep -v '^#' .env | xargs) && [ -f .env.local ] && export $(grep -v '^#' .env.local | xargs)
-  export PROJECT_NAME=${PROJECT_NAME:-$(basename $(pwd))}
-  export APP=${APP:-/app}
-  export WEBROOT=${WEBROOT:-docroot}
-  export MYSQL_HOST=${MYSQL_HOST:-mariadb}
-  export MYSQL_PORT=${MYSQL_PORT:-3306}
-  export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-$PROJECT_NAME}
-  export LOCALDEV_URL=${LOCALDEV_URL:-http://${PROJECT_NAME/[_ ]/-}.docker.amazee.io}
-  export COMPOSER=${COMPOSER:-composer.json}
-  export DRUPAL_PROFILE=${DRUPAL_PROFILE:-}
-  export DRUPAL_MODULE_PREFIX=${DRUPAL_MODULE_PREFIX:-mysite}
-  PHPCS_TARGETS=${PHPCS_TARGETS:-.} && export PHPCS_TARGETS=${PHPCS_TARGETS//,/ }
-  if [ "$CI" ]; then export ES_TPL=elasticsearch.ci.yml; fi
-  bash -c "$0" "$@"
-- '{{cmd}}'
-- '{{name}}'
+  - bash
+  - "-c"
+  - |
+    [ -f .env ] && export $(grep -v '^#' .env | xargs) && [ -f .env.local ] && export $(grep -v '^#' .env.local | xargs)
+    export PROJECT_NAME=${PROJECT_NAME:-$(basename $(pwd))}
+    export APP=${APP:-/app}
+    export WEBROOT=${WEBROOT:-docroot}
+    export MYSQL_HOST=${MYSQL_HOST:-mariadb}
+    export MYSQL_PORT=${MYSQL_PORT:-3306}
+    export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-$PROJECT_NAME}
+    export LOCALDEV_URL=${LOCALDEV_URL:-http://content-sdp.docker.internal}
+    export COMPOSER=${COMPOSER:-composer.json}
+    export DRUPAL_PROFILE=${DRUPAL_PROFILE:-}
+    export DRUPAL_MODULE_PREFIX=${DRUPAL_MODULE_PREFIX:-mysite}
+    PHPCS_TARGETS=${PHPCS_TARGETS:-.} && export PHPCS_TARGETS=${PHPCS_TARGETS//,/ }
+    if [ "$CI" ]; then export ES_TPL=elasticsearch.ci.yml; fi
+    bash -c "$0" "$@"
+  - '{{cmd}}'
+  - '{{name}}'

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -12,6 +12,4 @@ composer validate --ansi --strict --no-check-all --no-check-lock
 sed -i -e "/###/d" docker-compose.yml
 sed -i -e "s/##//" docker-compose.yml
 
-ahoy pull
-
 ahoy build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &job-build
     working_directory: /app
     docker:
-      - image: &builder-image singledigital/bay-ci-builder:5.x
+      - image: &builder-image ghcr.io/dpc-sdp/bay/ci-builder:5.x
         environment:
           INSTALL_NEW_SITE: 1
           LAGOON_ENVIRONMENT_TYPE: ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &job-build
     working_directory: /app
     docker:
-      - image: &builder-image ghcr.io/dpc-sdp/bay/ci-builder:5.x
+      - image: &builder-image "ghcr.io/dpc-sdp/bay/ci-builder:5.x"
         environment:
           INSTALL_NEW_SITE: 1
           LAGOON_ENVIRONMENT_TYPE: ci

--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -1,0 +1,9 @@
+content-sdp.docker.internal:80 {
+  reverse_proxy nginx:8080
+}
+elasticsearch.docker.internal:80 {
+  reverse_proxy elasticsearch:9200
+}
+mailhog.docker.internal:80 {
+  reverse_proxy mailhog:8025
+}

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,7 +1,7 @@
 ARG BAY_IMAGE_VERSION=5.x
 
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
-FROM singledigital/bay-cli:${BAY_IMAGE_VERSION}
+FROM "ghcr.io/dpc-sdp/bay/php-cli:${BAY_IMAGE_VERSION}"
 ARG COMPOSER
 
 ENV MYSQL_HOST=mariadb \

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -21,7 +21,7 @@ ADD dpc-sdp /app/dpc-sdp
 COPY composer.json .env composer.* /app/
 
 RUN echo "memory_limit=-1" >> /usr/local/etc/php/conf.d/memory.ini \
-    && composer install -n --no-dev --ansi --prefer-dist --no-suggest --optimize-autoloader \
+    && COMPOSER=$COMPOSER composer install -n --no-dev --ansi --prefer-dist --no-suggest --optimize-autoloader \
     && rm -rf /usr/local/etc/php/conf.d/memory.ini
 
 COPY . /app

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-ARG BAY_IMAGE_VERSION=5.x
+ARG BAY_IMAGE_VERSION
 
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
 FROM ghcr.io/dpc-sdp/bay/php-cli:${BAY_IMAGE_VERSION}

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,7 +1,7 @@
 ARG BAY_IMAGE_VERSION=5.x
 
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
-FROM "ghcr.io/dpc-sdp/bay/php-cli:${BAY_IMAGE_VERSION}"
+FROM ghcr.io/dpc-sdp/bay/php-cli:${BAY_IMAGE_VERSION}
 ARG COMPOSER
 
 ENV MYSQL_HOST=mariadb \

--- a/.docker/Dockerfile.elasticsearch
+++ b/.docker/Dockerfile.elasticsearch
@@ -1,10 +1,9 @@
-FROM amazeeio/elasticsearch:latest
+ARG BAY_IMAGE_VERSION
 ARG ES_TPL
 
-ENV ES_TPL=${ES_TPL:-elasticsearch.yml}
+FROM "ghcr.io/dpc-sdp/bay/elasticsearch:${BAY_IMAGE_VERSION}"
 
-RUN bin/elasticsearch-plugin install analysis-kuromoji \
-    && bin/elasticsearch-plugin install analysis-icu
+ENV ES_TPL=${ES_TPL:-elasticsearch.yml}
 
 COPY .docker/elasticsearch.yml .docker/elasticsearch.* /tmp/elasticsearch/
 

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -1,11 +1,13 @@
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.nginx
+ARG BAY_IMAGE_VERSION
 ARG CLI_IMAGE
-ARG BAY_IMAGE_VERSION=5.x
-
 FROM ${CLI_IMAGE:-cli} as cli
 
-FROM singledigital/bay-nginx:${BAY_IMAGE_VERSION}
+FROM "ghcr.io/dpc-sdp/bay/nginx:${BAY_IMAGE_VERSION}"
 
 ENV WEBROOT=docroot
+
+COPY .docker/global_redirects.conf /etc/nginx/helpers/global_redirects.conf
+RUN fix-permissions /etc/nginx
 
 COPY --from=cli /app /app

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -7,7 +7,4 @@ FROM "ghcr.io/dpc-sdp/bay/nginx:${BAY_IMAGE_VERSION}"
 
 ENV WEBROOT=docroot
 
-COPY .docker/global_redirects.conf /etc/nginx/helpers/global_redirects.conf
-RUN fix-permissions /etc/nginx
-
 COPY --from=cli /app /app

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -1,9 +1,8 @@
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
+ARG BAY_IMAGE_VERSION
 ARG CLI_IMAGE
-ARG BAY_IMAGE_VERSION=5.x
-
 FROM ${CLI_IMAGE:-cli} as cli
 
-FROM singledigital/bay-php:${BAY_IMAGE_VERSION}
+FROM ghcr.io/dpc-sdp/bay/php-fpm:${BAY_IMAGE_VERSION}
 
 COPY --from=cli /app /app

--- a/.docker/elasticsearch.ci.yml
+++ b/.docker/elasticsearch.ci.yml
@@ -2,10 +2,7 @@ cluster.name: "docker-cluster"
 network.host: 0.0.0.0
 transport.host: localhost
 
-# minimum_master_nodes need to be explicitly set when bound on a public IP
-# set to 1 to allow single node clusters
-# Details: https://github.com/elastic/elasticsearch/pull/17288
-discovery.zen.minimum_master_nodes: 1
+discovery.type: single-node
 xpack.license.self_generated.type: basic
 xpack.security.enabled: false
 

--- a/.docker/elasticsearch.yml
+++ b/.docker/elasticsearch.yml
@@ -1,10 +1,7 @@
 cluster.name: "docker-cluster"
 network.host: 0.0.0.0
 
-# minimum_master_nodes need to be explicitly set when bound on a public IP
-# set to 1 to allow single node clusters
-# Details: https://github.com/elastic/elasticsearch/pull/17288
-discovery.zen.minimum_master_nodes: 1
+discovery.type: single-node
 xpack.license.self_generated.type: basic
 xpack.security.enabled: false
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Tools used for development of Tide distribution and modules.
 2. Make sure that all local web development services are shut down (`apache/nginx`, `mysql`, `MAMP` etc).
 
 ## Local environment setup
-3. `curl https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install | bash`
-4. `pygmy up`
-5. `ahoy build` 
+1`curl https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install | bash`
+2`ahoy build` 
 
 ## Available `ahoy` commands
 Run each command as `ahoy <command>`.

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -28,7 +28,10 @@
         "phpunit/phpunit": "^8.5.14 || ^9",
         "drupal/core-dev":"9.4.x",
         "phpspec/prophecy-phpunit":"^2",
-        "weitzman/drupal-test-traits": "^1.5"
+        "weitzman/drupal-test-traits": "^1.5",
+        "php-http/message": "^1.16",
+        "php-http/message-factory": "^1.1",
+        "guzzlehttp/psr7": "^1.9"
     },
     "provide": {
         "drupal/ckeditor": "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,6 @@ services:
       << : *default-environment
       COMPOSER_MEMORY_LIMIT: -1
     << : *default-volumes
-    volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
-      - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
     labels:
       lagoon.type: cli-persistent
       lagoon.persistent: /app/docroot/sites/default/files/
@@ -80,16 +78,16 @@ services:
       << : *default-environment
     depends_on:
       - cli
-    networks:
-      - amazeeio-network
-      - default
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.persistent: /app/docroot/sites/default/files/
       lagoon.persistent.class: slow
       lagoon.name: nginx-php
     expose:
-    - "8080"
+      - "8080"
+    ports:
+      - "8888:8080"
+
   php:
     build:
       context: .
@@ -109,7 +107,7 @@ services:
       lagoon.name: nginx-php
 
   mariadb:
-    image: amazeeio/mariadb-drupal
+    image: "ghcr.io/dpc-sdp/bay/mariadb:${BAY_IMAGE_VERSION:-5.x}"
     environment:
       << : *default-environment
     ports:
@@ -127,20 +125,40 @@ services:
       context: .
       dockerfile: .docker/Dockerfile.elasticsearch
       args:
-      - ES_TPL=${ES_TPL:-elasticsearch.yml}
+        ES_TPL: ${ES_TPL:-elasticsearch.yml}
+        BAY_IMAGE_VERSION: *bay-image-version
+    ports:
+      - "9200:9200"
     labels:
       lagoon.type: none
 
   chrome:
-    image: selenium/standalone-chrome:3.141.59-oxygen
+    image: seleniarm/standalone-chromium:101.0
     shm_size: '1gb'
     environment:
-      << : *default-environment
-    << : *default-volumes
+      <<: *default-environment
+    <<: *default-volumes
     depends_on:
       - cli
     labels:
       lagoon.type: none
+
+  clamav:
+    image: "ghcr.io/dpc-sdp/bay/clamav:${BAY_IMAGE_VERSION:-5.x}"
+    environment:
+      <<: *default-environment
+    ports:
+      - "3310"
+    labels:
+      lagoon.type: none
+
+  proxy:
+    image: caddy:latest
+    ports:
+      - "${LOCAL_PORT:-80}:80"
+    volumes:
+      - $PWD/.docker:/etc/caddy
+      - $PWD/.docker/Caddyfile:/etc/caddy/Caddyfile
 
 networks:
   amazeeio-network:


### PR DESCRIPTION
Required so that all tide libs can pull in the latest dev stack for building.