### PR TITLE
[SDPAP-7655] Use statements sorted alpha

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -5,18 +5,18 @@
  * Feature context for Behat testing.
  */
 
-use Drupal\DrupalExtension\Context\DrupalContext;
-use DrevOps\BehatSteps\WatchdogTrait;
+use DrevOps\BehatSteps\ContentTrait;
 use DrevOps\BehatSteps\FieldTrait;
 use DrevOps\BehatSteps\JsTrait;
 use DrevOps\BehatSteps\LinkTrait;
-use DrevOps\BehatSteps\PathTrait;
-use DrevOps\BehatSteps\ResponseTrait;
-use DrevOps\BehatSteps\ContentTrait;
 use DrevOps\BehatSteps\MediaTrait;
 use DrevOps\BehatSteps\MenuTrait;
+use DrevOps\BehatSteps\PathTrait;
+use DrevOps\BehatSteps\ResponseTrait;
 use DrevOps\BehatSteps\TaxonomyTrait;
 use DrevOps\BehatSteps\VisibilityTrait;
+use DrevOps\BehatSteps\WatchdogTrait;
+use Drupal\DrupalExtension\Context\DrupalContext;
 
 /**
  * Defines application features from the specific context.


### PR DESCRIPTION
While working on https://digital-vic.atlassian.net/browse/SDPAP-7655
I got CI test errors that the Use statements should be sorted alphabetically. 
![Screenshot 2023-06-14 at 11 24 33 am](https://github.com/dpc-sdp/dev-tools/assets/47239456/222891b2-a1da-45c0-a7a9-6d6a99d6a83d)

