### PR TITLE
Add missing docker variables in dev-tools for ahoy config

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -184,6 +184,8 @@ entrypoint:
   - "-c"
   - |
     [ -f .env ] && export $(grep -v '^#' .env | xargs) && [ -f .env.local ] && export $(grep -v '^#' .env.local | xargs)
+    export DOCKER_BUILDKIT=0
+    export COMPOSE_DOCKER_CLI_BUILD=0
     export PROJECT_NAME=${PROJECT_NAME:-$(basename $(pwd))}
     export APP=${APP:-/app}
     export WEBROOT=${WEBROOT:-docroot}


### PR DESCRIPTION
As per discussion in slack, missing these variables causes the following build issue in tide modules:

```
=> CANCELED [tide_core 8/8] RUN echo "memory_limit=-1" >> /usr/local/etc/php/conf.d/memory.ini     && COMPOSER=composer.build.json composer install -n --no-dev --ansi --prefer-dist --no-suggest --optimiz  3.7s
------
 > [tide_core-php internal] load metadata for docker.io/library/tide_core:latest:
------
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```