### PR TITLE
Update dockerhost to be compatible with colima for xdebug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ x-environment:
   # Uncomment to enable Xdebug and then restart via `ahoy up`.
   #XDEBUG_ENABLE: "true"
   DOCKERHOST: host.docker.internal
+  # Comment out the above and uncomment the below if you are using Colima rather than Docker Desktop
+  #DOCKERHOST: 192.168.5.2
 
 services:
 


### PR DESCRIPTION
`host.docker.internal` is wildly inconsistient in my tests with Colima, but the host IP will always be fixed to this IP in the Colima stack, so this is fine.

Tested with tide_search and it works as expected.