### PR TITLE
Removed password strength fork reference from composer dev.

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -65,7 +65,7 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8",
-            "exclude": ["drupal/token_conditions", "drupal/password_strength", "drupal/console", "drupal/console-core", "drupal/console-extend-plugin", "drupal/ckeditor_templates", "drupal/create_menus_permission"]
+            "exclude": ["drupal/token_conditions", "drupal/console", "drupal/console-core", "drupal/console-extend-plugin", "drupal/ckeditor_templates", "drupal/create_menus_permission"]
         },
         "asset-packagist": {
             "type": "composer",
@@ -411,11 +411,6 @@
             "type": "vcs",
             "no-api": true,
             "url": "https://github.com/dpc-sdp/token_conditions.git"
-        },
-        "drupal/password_strength": {
-            "type": "vcs",
-            "no-api": true,
-            "url": "https://github.com/dpc-sdp/password_strength.git"
         },
         "drupal/ckeditor_templates": {
             "type": "vcs",


### PR DESCRIPTION
A new version compatible with D10 is released.
https://www.drupal.org/project/password_strength/releases/8.x-2.0-beta3