### PR TITLE
added mink browserkit driver

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -23,7 +23,7 @@ default:
       selenium2:
         wd_host: "http://chrome:4444/wd/hub"
         capabilities: { "browser": "chrome", "version": "*", "marionette": true }
-      goutte: ~
+      browserkit_http: ~
       ajax_timeout: 5
       browser_name: chrome
       javascript_session: selenium2

--- a/composer.dev.json
+++ b/composer.dev.json
@@ -13,7 +13,9 @@
         "webflo/drupal-finder": "^1.0"
     },
     "require-dev": {
-        "behat/behat": "^3.5",
+        "behat/behat": "~3.5",
+        "behat/mink": "^1.11",
+        "behat/mink-browserkit-driver": "^2.2",
         "behat/mink-selenium2-driver": "^1.4",
         "chi-teck/drupal-code-generator": "^3.0",
         "squizlabs/php_codesniffer": "3.7.1",

--- a/tests/behat/bootstrap/TideCommonTrait.php
+++ b/tests/behat/bootstrap/TideCommonTrait.php
@@ -22,10 +22,7 @@ trait TideCommonTrait {
   }
 
   /**
-   * Creates and authenticates a user with the given role(s).
-   *
-   * @Given I am logged in as a user with the :role role(s)
-   * @Given I am logged in as a/an :role
+   * Overriding parent function.
    */
   public function assertAuthenticatedByRole($role) {
     // Override parent assertion to allow using 'anonymous user' role without


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-9261
### Problem/Motivation
We need to install mink browserkit behat package in dev-tools to avoid the test errors in tide modules as behat/mink-goutte-driver is abandoned and no longer maintained. 

### Fix

### Related PRs

### Screenshots

### TODO
